### PR TITLE
Fix header case handling for Google Sheets

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -8,24 +8,33 @@ function getSheet_(name) {
 function getRows(sheetName) {
   const sheet = getSheet_(sheetName);
   const data = sheet.getDataRange().getValues();
-  const headers = data.shift();
+  const rawHeaders = data.shift();
+  // Normaliza cabeçalhos para letras minúsculas
+  const headers = rawHeaders.map(h => String(h).toLowerCase());
   return data.map(row => headers.reduce((o, h, i) => (o[h] = row[i], o), {}));
 }
 
 function addRow(sheetName, row) {
   const sheet = getSheet_(sheetName);
-  const headers = sheet.getDataRange().getValues()[0];
+  const rawHeaders = sheet.getDataRange().getValues()[0];
+  const headers = rawHeaders.map(h => String(h).toLowerCase());
+
+  // Converte as chaves do objeto recebido para letras minúsculas
+  const lowerRow = Object.keys(row).reduce((acc, k) => {
+    acc[String(k).toLowerCase()] = row[k];
+    return acc;
+  }, {});
 
   // Atribui um ID incremental se a planilha possuir a coluna "id" e o valor
   // ainda não tiver sido definido no objeto recebido.
   const idIdx = headers.indexOf('id');
-  if (idIdx > -1 && !row.id) {
+  if (idIdx > -1 && !lowerRow.id) {
     // getLastRow retorna o número da última linha com dados. Como a primeira
     // linha contém os cabeçalhos, o próximo ID corresponde a lastRow.
-    row.id = sheet.getLastRow();
+    lowerRow.id = sheet.getLastRow();
   }
 
-  const values = headers.map(h => row[h] || '');
+  const values = headers.map(h => lowerRow[h] || '');
   sheet.appendRow(values);
   return { success: true };
 }
@@ -40,7 +49,8 @@ function uploadDocument(name, base64) {
 function login(email, senha) {
   const sheet = getSheet_('user');
   const data = sheet.getDataRange().getValues();
-  const headers = data.shift();
+  const rawHeaders = data.shift();
+  const headers = rawHeaders.map(h => String(h).toLowerCase());
   const emailIdx = headers.indexOf('email');
   const senhaIdx = headers.indexOf('senha');
   if (emailIdx === -1 || senhaIdx === -1) {

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ e os documentos ficam em uma pasta no Google Drive.
    `docs`, `agenda`, `tarefas` e `fin`.
    - Adicione também a aba `user` com as colunas `email` e `senha` para definir
      quem pode acessar o sistema.
+   - Na aba `clientes`, utilize as colunas `id`, `nome`, `email`, `fone` e
+     `notas` exatamente nesses nomes (em letras minúsculas). O script considera
+     os cabeçalhos em minúsculas para salvar e ler os dados.
 2. Crie uma pasta no Google Drive para os arquivos enviados.
 3. Edite `Code.gs` e preencha as constantes `SPREADSHEET_ID` e
    `DOCS_FOLDER_ID` com os IDs correspondentes.


### PR DESCRIPTION
## Summary
- handle sheet headers case-insensitively when reading/writing
- document required column names for the `clientes` sheet in README

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_686c8755ceb48332984b32a5b6e99bb0