### PR TITLE
Add editing capability

### DIFF
--- a/index.html
+++ b/index.html
@@ -1248,6 +1248,7 @@
             </div>
             <form onsubmit="salvarTarefa(event);">
                 <input type="hidden" id="tarefa-id">
+                <input type="hidden" id="tarefa-status">
                 <div class="form-group"><label for="tarefa-descricao">Descrição *</label><textarea id="tarefa-descricao"
                         rows="3" required></textarea></div>
                 <div class="form-group"><label for="tarefa-prioridade">Prioridade</label><select id="tarefa-prioridade">
@@ -1356,6 +1357,11 @@
             return new Promise((res, rej) => {
                 google.script.run.withSuccessHandler(res).withFailureHandler(rej).login(email, senha);
             });
+        }
+
+        async function getRowById(table, id) {
+            const rows = await gsGetRows(table);
+            return rows.find(r => String(r.id) === String(id));
         }
 
         // -- INSTÂNCIAS DOS GRÁFICOS --
@@ -1675,6 +1681,7 @@
                         <td data-label="Status"><span class="badge ${t.status}">${t.status}</span></td>
                         <td data-label="Ações"><div class="actions">
                             <input type="checkbox" ${checked} onchange="concluirTarefa(${t.id}, this.checked)" title="Concluir">
+                            <button onclick="abrirModalTarefa(${t.id})" title="Editar"><i class="fa fa-edit"></i></button>
                             <button onclick="delRow('tarefas', ${t.id}, renderTarefas)" title="Excluir"><i class="fa fa-trash"></i></button>
                         </div></td>
                     </tr>`;
@@ -1712,6 +1719,7 @@
                         <td data-label="Caso">${ca.numero || ''}</td>
                         <td data-label="Status"><span class="badge ${f.status_pg}">${f.status_pg}</span></td>
                         <td data-label="Ações"><div class="actions">
+                            <button onclick="abrirModalFin('${f.tipo}', ${f.id})" title="Editar"><i class="fa fa-edit"></i></button>
                             <button onclick="delRow('fin', ${f.id}, loadFinanceiro)" title="Excluir"><i class="fa fa-trash"></i></button>
                         </div></td>
                     </tr>`;
@@ -1782,7 +1790,14 @@
             $('#modal-cliente form').reset();
             $('#cliente-id').value = '';
             if (id) {
-                showNotif('info', 'Edição de clientes não disponível nesta versão.');
+                const cli = await getRowById('clientes', id);
+                if (cli) {
+                    $('#cliente-id').value = cli.id;
+                    $('#cliente-nome').value = cli.nome || '';
+                    $('#cliente-email').value = cli.email || '';
+                    $('#cliente-fone').value = cli.fone || '';
+                    $('#cliente-notas').value = cli.notas || '';
+                }
             }
             $('#modal-cliente-titulo').innerText = id ? 'Editar Cliente' : 'Novo Cliente';
             $('#modal-cliente').classList.add('active');
@@ -1799,12 +1814,14 @@
             };
             if (!record.nome) return showNotif('danger', 'O nome do cliente é obrigatório.');
 
-            if (id) {
-                return showNotif('info', 'Edição de clientes não disponível nesta versão.');
-            }
             try {
-                await gsAddRow('clientes', record);
-                showNotif('success', 'Cliente salvo!');
+                if (id) {
+                    await gsUpdateRow('clientes', id, record);
+                    showNotif('success', 'Cliente atualizado!');
+                } else {
+                    await gsAddRow('clientes', record);
+                    showNotif('success', 'Cliente salvo!');
+                }
                 fecharModal('modal-cliente');
                 renderClientes();
                 loadDashboard();
@@ -1819,16 +1836,24 @@
             $('#caso-id').value = '';
             await populateSelect('caso-cliente', 'clientes', 'id', 'nome');
             if (id) {
-                showNotif('info', 'Edição de casos não disponível nesta versão.');
+                const caso = await getRowById('casos', id);
+                if (caso) {
+                    $('#caso-id').value = caso.id;
+                    await populateSelect('caso-cliente', 'clientes', 'id', 'nome', '', 'Selecione', caso.cliente_id);
+                    $('#caso-numero').value = caso.numero || '';
+                    $('#caso-partes').value = caso.partes || '';
+                    $('#caso-responsavel').value = caso.responsavel || '';
+                    $('#caso-data').value = caso.data ? caso.data.split('T')[0] : '';
+                    $('#caso-status').value = caso.status || 'Ativo';
+                }
             }
-            $('#modal-caso-titulo').innerText = 'Novo Caso';
+            $('#modal-caso-titulo').innerText = id ? 'Editar Caso' : 'Novo Caso';
             $('#modal-caso').classList.add('active');
         }
 
         async function salvarCaso(event) {
             event.preventDefault();
             const id = $('#caso-id').value;
-            if (id) return showNotif('info', 'Edição de casos não disponível nesta versão.');
             const record = {
                 cliente_id: $('#caso-cliente').value,
                 numero: $('#caso-numero').value,
@@ -1839,8 +1864,13 @@
             };
             if (!record.cliente_id || !record.numero) return showNotif('danger', 'Cliente e nº do processo são obrigatórios.');
             try {
-                await gsAddRow('casos', record);
-                showNotif('success', 'Caso salvo!');
+                if (id) {
+                    await gsUpdateRow('casos', id, record);
+                    showNotif('success', 'Caso atualizado!');
+                } else {
+                    await gsAddRow('casos', record);
+                    showNotif('success', 'Caso salvo!');
+                }
                 fecharModal('modal-caso');
                 renderCasos();
                 loadDashboard();
@@ -1899,16 +1929,26 @@
             await populateSelect('evento-cliente', 'clientes', 'id', 'nome');
             await populateSelect('evento-caso', 'casos', 'id', 'numero');
             if (id) {
-                showNotif('info', 'Edição de eventos não disponível nesta versão.');
+                const ev = await getRowById('agenda', id);
+                if (ev) {
+                    $('#evento-id').value = ev.id;
+                    $('#evento-titulo').value = ev.titulo || '';
+                    $('#evento-tipo').value = ev.tipo_evento || 'Audiência';
+                    $('#evento-datahora').value = ev.datahora ? ev.datahora.slice(0,16) : '';
+                    $('#evento-local').value = ev.local || '';
+                    await populateSelect('evento-cliente', 'clientes', 'id', 'nome', '', 'Selecione', ev.cliente_id);
+                    await populateSelect('evento-caso', 'casos', 'id', 'numero', '', 'Nenhum', ev.caso_id);
+                    $('#evento-status').value = ev.status || 'Agendado';
+                    $('#evento-descricao').value = ev.descricao || '';
+                }
             }
-            $('#evento-modal-titulo').innerText = 'Novo Evento / Prazo';
+            $('#evento-modal-titulo').innerText = id ? 'Editar Evento / Prazo' : 'Novo Evento / Prazo';
             $('#modal-evento').classList.add('active');
         }
 
         async function salvarEvento(event) {
             event.preventDefault();
             const id = $('#evento-id').value;
-            if (id) return showNotif('info', 'Edição de eventos não disponível nesta versão.');
             const record = {
                 titulo: $('#evento-titulo').value,
                 tipo_evento: $('#evento-tipo').value,
@@ -1921,8 +1961,13 @@
             };
             if (!record.titulo || !record.datahora) return showNotif('danger', 'Título e data/hora são obrigatórios.');
             try {
-                await gsAddRow('agenda', record);
-                showNotif('success', 'Evento salvo!');
+                if (id) {
+                    await gsUpdateRow('agenda', id, record);
+                    showNotif('success', 'Evento atualizado!');
+                } else {
+                    await gsAddRow('agenda', record);
+                    showNotif('success', 'Evento salvo!');
+                }
                 fecharModal('modal-evento');
                 renderAgenda();
                 loadDashboard();
@@ -1938,28 +1983,44 @@
             await populateSelect('tarefa-cliente', 'clientes', 'id', 'nome');
             await populateSelect('tarefa-caso', 'casos', 'id', 'numero');
             if (id) {
-                showNotif('info', 'Edição de tarefas não disponível nesta versão.');
+                const tarefa = await getRowById('tarefas', id);
+                if (tarefa) {
+                    $('#tarefa-id').value = tarefa.id;
+                    $('#tarefa-descricao').value = tarefa.descricao || '';
+                    $('#tarefa-prioridade').value = tarefa.prioridade || 'Baixa';
+                    $('#tarefa-prazo').value = tarefa.prazo ? tarefa.prazo.split('T')[0] : '';
+                    await populateSelect('tarefa-cliente', 'clientes', 'id', 'nome', '', 'Selecione', tarefa.cliente_id);
+                    await populateSelect('tarefa-caso', 'casos', 'id', 'numero', '', 'Nenhum', tarefa.caso_id);
+                    $('#tarefa-status').value = tarefa.status || 'Pendente';
+                }
+                $('#tarefa-modal-titulo').innerText = 'Editar Tarefa';
+            } else {
+                $('#tarefa-modal-titulo').innerText = 'Nova Tarefa';
+                $('#tarefa-status').value = 'Pendente';
             }
-            $('#tarefa-modal-titulo').innerText = 'Nova Tarefa';
             $('#modal-tarefa').classList.add('active');
         }
 
         async function salvarTarefa(event) {
             event.preventDefault();
             const id = $('#tarefa-id').value;
-            if (id) return showNotif('info', 'Edição de tarefas não disponível nesta versão.');
             const record = {
                 descricao: $('#tarefa-descricao').value,
                 prioridade: $('#tarefa-prioridade').value,
                 prazo: $('#tarefa-prazo').value,
                 cliente_id: $('#tarefa-cliente').value,
                 caso_id: $('#tarefa-caso').value,
-                status: 'Pendente'
+                status: $('#tarefa-status').value || 'Pendente'
             };
             if (!record.descricao) return showNotif('danger', 'A descrição é obrigatória.');
             try {
-                await gsAddRow('tarefas', record);
-                showNotif('success', 'Tarefa salva!');
+                if (id) {
+                    await gsUpdateRow('tarefas', id, record);
+                    showNotif('success', 'Tarefa atualizada!');
+                } else {
+                    await gsAddRow('tarefas', record);
+                    showNotif('success', 'Tarefa salva!');
+                }
                 fecharModal('modal-tarefa');
                 renderTarefas();
                 loadDashboard();
@@ -1987,16 +2048,27 @@
             await populateSelect('fin-cliente', 'clientes', 'id', 'nome');
             await populateSelect('fin-caso', 'casos', 'id', 'numero');
             if (id) {
-                showNotif('info', 'Edição financeira não disponível nesta versão.');
+                const fin = await getRowById('fin', id);
+                if (fin) {
+                    $('#fin-id').value = fin.id;
+                    $('#fin-tipo').value = fin.tipo;
+                    $('#fin-descricao').value = fin.descricao || '';
+                    $('#fin-categoria').value = fin.categoria || 'Honorários';
+                    $('#fin-valor').value = fin.valor || '';
+                    $('#fin-data').value = fin.data ? fin.data.split('T')[0] : '';
+                    $('#fin-status').value = fin.status_pg || 'Pendente';
+                    await populateSelect('fin-cliente', 'clientes', 'id', 'nome', '', 'Selecione', fin.cliente_id);
+                    await populateSelect('fin-caso', 'casos', 'id', 'numero', '', 'Nenhum', fin.caso_id);
+                    tipo = fin.tipo;
+                }
             }
-            $('#fin-titulo').innerText = tipo === 'Receber' ? 'Nova Receita' : 'Nova Despesa';
+            $('#fin-titulo').innerText = tipo === 'Receber' ? (id ? 'Editar Receita' : 'Nova Receita') : (id ? 'Editar Despesa' : 'Nova Despesa');
             $('#modal-fin').classList.add('active');
         }
 
         async function salvarFin(event) {
             event.preventDefault();
             const id = $('#fin-id').value;
-            if (id) return showNotif('info', 'Edição financeira não disponível nesta versão.');
             const record = {
                 descricao: $('#fin-descricao').value,
                 categoria: $('#fin-categoria').value,
@@ -2009,8 +2081,13 @@
             };
             if (!record.descricao || !record.valor || !record.data) return showNotif('danger', 'Preencha todos os campos obrigatórios.');
             try {
-                await gsAddRow('fin', record);
-                showNotif('success', 'Lançamento salvo!');
+                if (id) {
+                    await gsUpdateRow('fin', id, record);
+                    showNotif('success', 'Lançamento atualizado!');
+                } else {
+                    await gsAddRow('fin', record);
+                    showNotif('success', 'Lançamento salvo!');
+                }
                 fecharModal('modal-fin');
                 loadFinanceiro();
                 loadDashboard();


### PR DESCRIPTION
## Summary
- enable editing for clientes, casos, eventos, tarefas and financeiro
- add helper to fetch a single row by id
- include edit buttons for tarefas and financeiro

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686e5079319c83328a1a1be9f1b8d6e8