### PR TITLE
Enable CSV export

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -145,3 +145,19 @@ function login(email, senha) {
   const ok = data.some(row => row[emailIdx] == email && row[senhaIdx] == senha);
   return { success: ok };
 }
+
+function exportSheetCsv(sheetName) {
+  const sheet = getSheet_(sheetName);
+  const data = sheet.getDataRange().getValues();
+  const csv = data.map(row => row.map(val => {
+    if (val instanceof Date) {
+      val = Utilities.formatDate(val, 'UTC', "yyyy-MM-dd'T'HH:mm:ss'Z'");
+    }
+    val = String(val || '').replace(/"/g, '""');
+    return /[",\n]/.test(val) ? `"${val}"` : val;
+  }).join(',')).join('\r\n');
+  const blob = Utilities.newBlob(csv, 'text/csv', `${sheetName}.csv`);
+  const file = DriveApp.createFile(blob);
+  SpreadsheetApp.flush();
+  return { url: file.getUrl(), name: file.getName(), id: file.getId() };
+}

--- a/index.html
+++ b/index.html
@@ -1074,6 +1074,7 @@
                     </select>
                     <button class="btn btn-success" onclick="abrirModalCaso()"><i class="fa fa-plus"></i> Novo
                         Caso</button>
+                    <button class="btn btn-info" onclick="exportarDados('casos')"><i class="fa fa-download"></i> Exportar CSV</button>
                 </div>
                 <div class="table-wrapper" id="tabela-casos"></div>
             </div>
@@ -1088,6 +1089,7 @@
                         onkeyup="renderClientes()">
                     <button class="btn btn-success" onclick="abrirModalCliente()"><i class="fa fa-plus"></i> Novo
                         Cliente</button>
+                    <button class="btn btn-info" onclick="exportarDados('clientes')"><i class="fa fa-download"></i> Exportar CSV</button>
                 </div>
                 <div class="table-wrapper" id="tabela-clientes"></div>
             </div>
@@ -1106,6 +1108,7 @@
                     </select>
                     <button class="btn btn-success" onclick="abrirModalDocumento()"><i class="fa fa-upload"></i> Anexar
                         Documento</button>
+                    <button class="btn btn-info" onclick="exportarDados('docs')"><i class="fa fa-download"></i> Exportar CSV</button>
                 </div>
                 <div class="table-wrapper" id="tabela-documentos"></div>
             </div>
@@ -1126,6 +1129,7 @@
                         <option>Prazo Processual</option>
                         <option>Outro</option>
                     </select>
+                    <button class="btn btn-info" onclick="exportarDados('agenda')"><i class="fa fa-download"></i> Exportar CSV</button>
                 </div>
                 <div class="table-wrapper" id="tabela-agenda"></div>
             </div>
@@ -1149,6 +1153,7 @@
                         <option>Média</option>
                         <option>Baixa</option>
                     </select>
+                    <button class="btn btn-info" onclick="exportarDados('tarefas')"><i class="fa fa-download"></i> Exportar CSV</button>
                 </div>
                 <div class="table-wrapper" id="tabela-tarefas"></div>
             </div>
@@ -1166,6 +1171,7 @@
                             Nova Receita</button>
                         <button class="btn btn-danger" onclick="abrirModalFin('Pagar')"><i class="fa fa-minus"></i> Nova
                             Despesa</button>
+                        <button class="btn btn-info" onclick="exportarDados('fin')"><i class="fa fa-download"></i> Exportar CSV</button>
                     </div>
                 </div>
                 <div class="table-wrapper" id="tabela-financeiro"></div>
@@ -2283,8 +2289,25 @@
             }
         }
 
-        async function exportarDados(tableName) {
-            showNotif('info', 'Funcionalidade não implementada nesta versão.');
+        function exportarDados(tableName) {
+            showNotif('info', 'Gerando CSV, aguarde...');
+            google.script.run.withSuccessHandler(res => {
+                if (res && res.url) {
+                    const a = document.createElement('a');
+                    a.href = res.url;
+                    a.download = `${tableName}.csv`;
+                    a.target = '_blank';
+                    document.body.appendChild(a);
+                    a.click();
+                    a.remove();
+                    showNotif('success', 'Arquivo pronto para download.');
+                } else {
+                    showNotif('danger', 'Falha ao gerar arquivo.');
+                }
+            }).withFailureHandler(e => {
+                showNotif('danger', 'Erro: ' + e.message);
+                console.error(e);
+            }).exportSheetCsv(tableName);
         }
 
         /* ------------- CONTROLE DO SIDEBAR ------------- */


### PR DESCRIPTION
## Summary
- implement `exportSheetCsv` in `Code.gs` to create CSVs from sheets and return a Drive URL
- call this Apps Script function from `exportarDados` in `index.html`
- add Exportar CSV buttons to all listing screens

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686e68fde88c833290b72bcb043aeb76