### PR TITLE
Add notification email functionality

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -163,3 +163,16 @@ function exportSheetCsv(sheetName) {
   SpreadsheetApp.flush();
   return { url: file.getUrl(), name: file.getName(), id: file.getId() };
 }
+
+function sendNotification(email, assunto, mensagem) {
+  if (!email) {
+    return { success: false, message: 'Email ausente' };
+  }
+  try {
+    if (Array.isArray(email)) email = email.join(',');
+    MailApp.sendEmail(email, assunto || '', mensagem || '');
+    return { success: true };
+  } catch (e) {
+    return { success: false, message: e.message };
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1431,6 +1431,13 @@
             });
         }
 
+        function gsSendNotification(email, assunto, mensagem) {
+            return new Promise((res, rej) => {
+                google.script.run.withSuccessHandler(res).withFailureHandler(rej)
+                    .sendNotification(email, assunto, mensagem);
+            });
+        }
+
         async function getRowById(table, id) {
             const rows = await gsGetRows(table);
             return rows.find(r => String(r.id) === String(id));
@@ -2167,6 +2174,26 @@
                     await gsAddRow('agenda', record);
                     showNotif('success', 'Evento salvo!');
                 }
+
+                const recipients = [];
+                if (record.cliente_id) {
+                    const cli = await getRowById('clientes', record.cliente_id);
+                    if (cli && cli.email && (!cli.notificar || String(cli.notificar).toLowerCase() !== 'nao')) {
+                        recipients.push(cli.email);
+                    }
+                }
+                if (record.caso_id) {
+                    const caso = await getRowById('casos', record.caso_id);
+                    if (caso && caso.responsavel && caso.responsavel.includes('@')) {
+                        recipients.push(caso.responsavel);
+                    }
+                }
+                if (recipients.length) {
+                    const assunto = `${id ? 'Atualização' : 'Novo'} evento: ${record.titulo}`;
+                    const mensagem = `Título: ${record.titulo}\nData/Hora: ${fmtDateTime(record.datahora)}\nStatus: ${record.status}`;
+                    await gsSendNotification(recipients.join(','), assunto, mensagem);
+                }
+
                 fecharModal('modal-evento');
                 renderAgenda();
                 loadDashboard();
@@ -2220,6 +2247,26 @@
                     await gsAddRow('tarefas', record);
                     showNotif('success', 'Tarefa salva!');
                 }
+
+                const recipients = [];
+                if (record.cliente_id) {
+                    const cli = await getRowById('clientes', record.cliente_id);
+                    if (cli && cli.email && (!cli.notificar || String(cli.notificar).toLowerCase() !== 'nao')) {
+                        recipients.push(cli.email);
+                    }
+                }
+                if (record.caso_id) {
+                    const caso = await getRowById('casos', record.caso_id);
+                    if (caso && caso.responsavel && caso.responsavel.includes('@')) {
+                        recipients.push(caso.responsavel);
+                    }
+                }
+                if (recipients.length) {
+                    const assunto = `${id ? 'Atualização' : 'Nova'} tarefa`;
+                    const mensagem = `Descrição: ${record.descricao}\nPrazo: ${record.prazo || 'Sem prazo'}\nStatus: ${record.status}`;
+                    await gsSendNotification(recipients.join(','), assunto, mensagem);
+                }
+
                 fecharModal('modal-tarefa');
                 renderTarefas();
                 loadDashboard();


### PR DESCRIPTION
## Summary
- add `sendNotification` server-side function using `MailApp.sendEmail`
- expose `gsSendNotification` helper on the client
- trigger email notifications when creating or updating events and tasks

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686e75f1a5a48332bacded01ffdab8c9