### PR TITLE
Adjust painel mobile layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -273,6 +273,12 @@
             margin-bottom: 2.5rem;
         }
 
+        @media (max-width: 768px) {
+            #painel-cards {
+                grid-template-columns: repeat(2, 1fr);
+            }
+        }
+
         #resumo-financeiro.painel-cards {
             display: flex;
             justify-content: center;


### PR DESCRIPTION
## Summary
- tweak `#painel-cards` so cards display two per row on small screens
- confirm existing responsive layout for charts

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686e98103d14833297825dcd25fd06b9