### PR TITLE
Add GitHub Pages hosting instructions

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -164,3 +164,38 @@ function exportSheetCsv(sheetName) {
   return { url: file.getUrl(), name: file.getName(), id: file.getId() };
 }
 
+function doPost(e) {
+  const data = JSON.parse(e.postData.contents || '{}');
+  const { action, args } = data;
+  let result;
+  switch (action) {
+    case 'getRows':
+      result = getRows(args.sheet);
+      break;
+    case 'addRow':
+      result = addRow(args.sheet, args.row);
+      break;
+    case 'updateRow':
+      result = updateRow(args.sheet, args.id, args.row);
+      break;
+    case 'deleteRow':
+      result = deleteRow(args.sheet, args.id);
+      break;
+    case 'uploadDocument':
+      result = uploadDocument(args.name, args.base64);
+      break;
+    case 'login':
+      result = login(args.email, args.senha);
+      break;
+    case 'exportSheetCsv':
+      result = exportSheetCsv(args.sheet);
+      break;
+    default:
+      result = { error: 'Ação inválida' };
+  }
+  return ContentService
+    .createTextOutput(JSON.stringify(result))
+    .setMimeType(ContentService.MimeType.JSON)
+    .setHeader('Access-Control-Allow-Origin', '*');
+}
+

--- a/README.md
+++ b/README.md
@@ -37,3 +37,72 @@ letras minúsculas):
 - **fin**: `id`, `descricao`, `categoria`, `valor`, `data`, `status_pg`, `cliente_id`, `caso_id`, `tipo`
 
 Para datas e prazos, o script converte automaticamente valores do tipo Date em um formato ISO (yyyy-MM-dd'T'HH:mm:ss'Z'). Isso garante que o painel consiga interpretar corretamente as datas retornadas pela planilha.
+
+## Hospedando o front-end no GitHub Pages
+
+Caso deseje servir o arquivo `index.html` a partir do GitHub Pages em vez de utilizar o serviço de front-end do Apps Script, siga os passos abaixo. Assim é possível manter a planilha e a pasta do Google Drive como "banco de dados" e acessar o backend via requisições HTTP.
+
+1. **Exponha o Apps Script como uma API.**
+   - No arquivo `Code.gs`, adicione uma função `doPost(e)` responsável por receber uma chamada HTTP e redirecionar para as demais funções (`getRows`, `addRow`, `updateRow` etc.). Um exemplo de implementação está abaixo:
+
+   ```javascript
+   function doPost(e) {
+     const data = JSON.parse(e.postData.contents || '{}');
+     const { action, args } = data;
+     let result;
+     switch (action) {
+       case 'getRows':
+         result = getRows(args.sheet);
+         break;
+       case 'addRow':
+         result = addRow(args.sheet, args.row);
+         break;
+       case 'updateRow':
+         result = updateRow(args.sheet, args.id, args.row);
+         break;
+       case 'deleteRow':
+         result = deleteRow(args.sheet, args.id);
+         break;
+       case 'uploadDocument':
+         result = uploadDocument(args.name, args.base64);
+         break;
+       case 'login':
+         result = login(args.email, args.senha);
+         break;
+       case 'exportSheetCsv':
+         result = exportSheetCsv(args.sheet);
+         break;
+       default:
+         result = { error: 'Ação inválida' };
+     }
+     return ContentService
+       .createTextOutput(JSON.stringify(result))
+       .setMimeType(ContentService.MimeType.JSON)
+       .setHeader('Access-Control-Allow-Origin', '*');
+   }
+   ```
+
+   Essa função permite que chamadas `POST` sejam feitas de qualquer origem (graças ao cabeçalho `Access-Control-Allow-Origin`), retornando sempre um JSON.
+
+2. **Publique o Apps Script como Web App.**
+   - Escolha a opção "Qualquer um, mesmo anônimo" para acesso. Copie a URL gerada após a publicação; ela será usada pelo front-end.
+
+3. **Adapte `index.html`** para realizar requisições via `fetch` para a URL do Web App. Um helper simples pode ser utilizado:
+
+   ```javascript
+   const API_URL = 'https://script.google.com/macros/s/SEU_ID/exec';
+
+   function api(action, args) {
+     return fetch(API_URL, {
+       method: 'POST',
+       body: JSON.stringify({ action, args }),
+       headers: { 'Content-Type': 'application/json' }
+     }).then(r => r.json());
+   }
+   ```
+
+   Em seguida, substitua as chamadas `google.script.run` por `api('acao', {...})`.
+
+4. **Hospede o arquivo `index.html`** no GitHub Pages (por exemplo, através da branch `gh-pages`).
+
+Dessa forma, a interface continua consumindo os dados da planilha e da pasta do Drive por meio das funções do Apps Script, mas o HTML fica hospedado externamente.


### PR DESCRIPTION
## Summary
- document how to host `index.html` via GitHub Pages
- implement `doPost` API endpoint in `Code.gs`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68729c435f108332a6d6d6e172a7ec53