### PR TITLE
Implement CORS preflight handler

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -196,6 +196,15 @@ function doPost(e) {
   return ContentService
     .createTextOutput(JSON.stringify(result))
     .setMimeType(ContentService.MimeType.JSON)
-    .setHeader('Access-Control-Allow-Origin', '*');
+    .setHeader('Access-Control-Allow-Origin', '*')
+    .setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+}
+
+function doGet(e) {
+  return ContentService
+    .createTextOutput('')
+    .setMimeType(ContentService.MimeType.JSON)
+    .setHeader('Access-Control-Allow-Origin', '*')
+    .setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
 }
 

--- a/README.md
+++ b/README.md
@@ -75,10 +75,11 @@ Caso deseje servir o arquivo `index.html` a partir do GitHub Pages em vez de uti
        default:
          result = { error: 'Ação inválida' };
      }
-     return ContentService
-       .createTextOutput(JSON.stringify(result))
-       .setMimeType(ContentService.MimeType.JSON)
-       .setHeader('Access-Control-Allow-Origin', '*');
+       return ContentService
+         .createTextOutput(JSON.stringify(result))
+         .setMimeType(ContentService.MimeType.JSON)
+         .setHeader('Access-Control-Allow-Origin', '*')
+         .setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
    }
    ```
 


### PR DESCRIPTION
## Summary
- respond to CORS preflight requests with a new `doGet` function
- allow POST and OPTIONS methods in the Apps Script web app

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6872b39dc4088332b7ed9a498fbfa780