### PR TITLE
Switch to Firebase email/password login

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -134,20 +134,6 @@ function uploadDocument(name, base64) {
   return { id: file.getId(), name: file.getName(), url: file.getUrl() };
 }
 
-function login(email, senha) {
-  const sheet = getSheet_('user');
-  const data = sheet.getDataRange().getValues();
-  const rawHeaders = data.shift();
-  const headers = rawHeaders.map(h => String(h).toLowerCase());
-  const emailIdx = headers.indexOf('email');
-  const senhaIdx = headers.indexOf('senha');
-  if (emailIdx === -1 || senhaIdx === -1) {
-    throw new Error('Sheet "user" must have columns "email" and "senha"');
-  }
-  const ok = data.some(row => row[emailIdx] == email && row[senhaIdx] == senha);
-  return { success: ok };
-}
-
 function exportSheetCsv(sheetName) {
   const sheet = getSheet_(sheetName);
   const data = sheet.getDataRange().getValues();
@@ -183,9 +169,6 @@ function doPost(e) {
       break;
     case 'uploadDocument':
       result = uploadDocument(args.name, args.base64);
-      break;
-    case 'login':
-      result = login(args.email, args.senha);
       break;
     case 'exportSheetCsv':
       result = exportSheetCsv(args.sheet);

--- a/README.md
+++ b/README.md
@@ -7,16 +7,17 @@ e os documentos ficam em uma pasta no Google Drive.
 ## Configuração
 1. Crie uma planilha no Google Sheets contendo as abas `clientes`, `casos`,
    `docs`, `agenda`, `tarefas` e `fin`.
-   - Adicione também a aba `user` com as colunas `email` e `senha` para definir
-     quem pode acessar o sistema.
    - Na aba `clientes`, utilize as colunas `id`, `nome`, `email`, `fone` e
      `notas` exatamente nesses nomes (em letras minúsculas). O script considera
      os cabeçalhos em minúsculas para salvar e ler os dados.
 2. Crie uma pasta no Google Drive para os arquivos enviados.
-3. No editor do Apps Script, abra **Arquivo > Propriedades do projeto** e, na
+3. Configure um projeto no Firebase e habilite a autenticação por e-mail e
+   senha. Copie as chaves do projeto e preencha o objeto `firebaseConfig` em
+   `index.html`.
+4. No editor do Apps Script, abra **Arquivo > Propriedades do projeto** e, na
    aba **Propriedades do Script**, adicione `SPREADSHEET_ID` e
    `DOCS_FOLDER_ID` com os respectivos IDs.
-4. Publique o projeto como aplicativo da Web ou use a extensão do Apps Script
+5. Publique o projeto como aplicativo da Web ou use a extensão do Apps Script
    para serviço de backend.
 
 Ao carregar os dados dos documentos, o script verifica a pasta indicada em
@@ -27,8 +28,6 @@ pasta apareçam no painel.
 ## Estrutura das abas
 O sistema espera que cada aba da planilha possua as seguintes colunas (todas em
 letras minúsculas):
-
-- **user**: `email`, `senha`
 - **clientes**: `id`, `nome`, `email`, `fone`, `notas`
 - **casos**: `id`, `cliente_id`, `numero`, `partes`, `responsavel`, `data`, `status`
 - **docs**: `id`, `cliente_id`, `caso_id`, `titulo`, `file_id`, `file_nome`, `file_url`
@@ -63,12 +62,9 @@ Caso deseje servir o arquivo `index.html` a partir do GitHub Pages em vez de uti
        case 'deleteRow':
          result = deleteRow(args.sheet, args.id);
          break;
-       case 'uploadDocument':
-         result = uploadDocument(args.name, args.base64);
-         break;
-       case 'login':
-         result = login(args.email, args.senha);
-         break;
+      case 'uploadDocument':
+        result = uploadDocument(args.name, args.base64);
+        break;
        case 'exportSheetCsv':
          result = exportSheetCsv(args.sheet);
          break;

--- a/index.html
+++ b/index.html
@@ -1111,10 +1111,6 @@
         </div>
         <button id="btnLogin" class="btn" style="width: 100%;">Entrar</button>
         <div id="login-erro"></div>
-        <p style="text-align:center; margin-top:1.8rem; font-size: var(--fs-base); color:#666;">
-            Primeiro acesso? <a href="#" id="btnCriarConta" style="color:var(--accent); font-weight:600;">Criar
-                conta</a>
-        </p>
     </div>
 
     <div id="app" style="display:none">
@@ -1508,6 +1504,18 @@
     <!-- Google Apps Script runtime already provides google.script.run -->
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/index.global.min.js"></script>
+    <!-- Firebase -->
+    <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-auth-compat.js"></script>
+    <script>
+        const firebaseConfig = {
+            apiKey: "YOUR_API_KEY",
+            authDomain: "YOUR_AUTH_DOMAIN",
+            projectId: "YOUR_PROJECT_ID"
+        };
+        firebase.initializeApp(firebaseConfig);
+        const auth = firebase.auth();
+    </script>
     <script>
         // =================================================================================
         // PAINEL JURÍDICO - SCRIPT COMPLETO (Versão Supabase) - SPINNERS
@@ -1547,10 +1555,6 @@
 
         function gsUploadDocument(name, base64) {
             return api('uploadDocument', { name, base64 });
-        }
-
-        function gsLogin(email, senha) {
-            return api('login', { email, senha });
         }
 
 
@@ -2499,10 +2503,10 @@
             // Event listeners para login, etc.
             $('#btnLogin').addEventListener('click', handleLogin);
             $('#btnLogout').addEventListener('click', handleLogout);
-            $('#btnCriarConta').addEventListener('click', () => showNotif('info', 'Funcionalidade de criar conta ainda não implementada.'));
 
             // Checa a sessão do usuário ao carregar
             checkUserSession();
+            auth.onAuthStateChanged(checkUserSession);
             checkScreenSize();
 
             // Fecha modais ao clicar no fundo
@@ -2519,8 +2523,8 @@
 
         /* ------------- AUTENTICAÇÃO ------------- */
         function checkUserSession() {
-            const logged = localStorage.getItem('userLoggedIn') === '1';
-            if (logged) {
+            const user = auth.currentUser;
+            if (user) {
                 $('#login-panel').style.display = 'none';
                 $('#app').style.display = 'block';
                 abrirTab(0);
@@ -2534,24 +2538,16 @@
             const email = $('#login-email').value;
             const password = $('#login-senha').value;
             try {
-                const { success } = await gsLogin(email, password);
-                if (success) {
-                    localStorage.setItem('userLoggedIn', '1');
-                    $('#login-erro').style.display = 'none';
-                    checkUserSession();
-                } else {
-                    $('#login-erro').innerText = 'E-mail ou senha inválidos.';
-                    $('#login-erro').style.display = 'block';
-                }
+                await auth.signInWithEmailAndPassword(email, password);
+                $('#login-erro').style.display = 'none';
             } catch (e) {
-                $('#login-erro').innerText = 'Erro ao autenticar.';
+                $('#login-erro').innerText = 'E-mail ou senha inválidos.';
                 $('#login-erro').style.display = 'block';
             }
         }
 
         function handleLogout() {
-            localStorage.removeItem('userLoggedIn');
-            checkUserSession();
+            auth.signOut();
         }
 
     </script>


### PR DESCRIPTION
## Summary
- integrate Firebase Auth for email/password sign-in
- remove account creation link and associated event handler
- clean up Apps Script backend to drop login endpoint
- update documentation to explain Firebase config

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688920492a288332b5c569523f991a71